### PR TITLE
fix: support deprecated addListener

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ export default (query) => {
     const media = window.matchMedia(queryToMatch);
     if (media.matches !== matches) setMatches(media.matches);
     const listener = () => setMatches(media.matches);
-    media.addEventListener("change", listener);
-    return () => media.removeEventListener("change", listener);
+    media.addEventListener
+      ? media.addEventListener("change", listener)
+      : media.addListener(listener);
+    return () => media.removeEventListener
+      ? media.removeEventListener("change", listener)
+      : media.removeListener(listener);
   }, [matches, queryToMatch]);
 
   return matches;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rollup -c",
-    "test": "jest"
+    "test": "jest",
+    "prepublish":"npm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",


### PR DESCRIPTION
fixes crashes on iOS 12, as addListener is still used there.