### PR TITLE
fix: support deprecated addListener

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ export default (query) => {
     const media = window.matchMedia(queryToMatch);
     if (media.matches !== matches) setMatches(media.matches);
     const listener = () => setMatches(media.matches);
-    media.addEventListener("change", listener);
-    return () => media.removeEventListener("change", listener);
+    media.addEventListener
+      ? media.addEventListener("change", listener)
+      : media.addListener(listener);
+    return () => media.removeEventListener
+      ? media.removeEventListener("change", listener)
+      : media.removeListener(listener);
   }, [matches, queryToMatch]);
 
   return matches;


### PR DESCRIPTION
Fixes crash in Safari 13.1.3 