### PR TITLE
Improved media query resolutions

### DIFF
--- a/mediaQueries.js
+++ b/mediaQueries.js
@@ -1,5 +1,6 @@
 export default {
-  phone: '(min-width: 320px) and (max-width: 568px)',
-  tablet: '(min-width : 768px) and (max-width : 1024px)',
-  desktop: '(min-width : 1224px)',
+	phone_portrait: '(max-width: 567px)',
+	phone_landscape: '(min-width : 568px) and (max-width: 767px)',
+	tablet: '(min-width : 768px) and (max-width : 1024px)',
+	desktop: '(min-width : 1025px)',
 };


### PR DESCRIPTION
Hi! I loved this package, it is very handy. However I face an issue with the sizes. Right now there are gaps between 'phone' and 'tablet', and 'tablet' and 'desktop' which kind of screws up a bit the logic... Like, for instanse, if you 've got 600px or 1100px width neither is applied.
I wanted to use it to render either mobile or desktop menu, which works if I do either:

```
const mobileView = useReactSimpleMatchMedia('phone');
 return (
....
{mobileView && <BurgerMenu />)
{!mobileView && <MainNavItems />}
....
)
```

or 

```
const desktopView = useReactSimpleMatchMedia('desktop');

return (
....
{!desktopView && <BurgerMenu />)
{desktopView && <MainNavItems />}
....
)
```

but if the 'tablet' is in play in the end the logic is too complicated and defeats the purpose of using a 'simple' plugin.. 
My suggestion is to set media queries so there are no gaps between one view and another. As there can be a pretty big difference between low resolution phones and phone landscape on the newest models like iPhone 12 pro max, I have made a middle option which is "phone_landscape"

values are as following: 

media | value
phone_portrait |  (max-width: 567px)
phone_landscape | (min-width : 568px) and (max-width: 767px)
tablet | (min-width : 768px) and (max-width : 1024px)
desktop | (min-width : 1025px)

In this way nothing is left out and it works with the newest devices too.

I hope this will help and this improvement can help!
thanks!
